### PR TITLE
Skip invalid (not-connected) mappings

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,12 +19,18 @@ module.exports = function offsetLines (incomingSourceMap, lineOffset) {
         sourceRoot: incomingSourceMap.sourceRoot
     });
     consumer.eachMapping(function (m) {
-        generator.addMapping({
-            source: m.source,
-            name: m.name,
-            original: { line: m.originalLine, column: m.originalColumn },
-            generated: { line: m.generatedLine + lineOffset, column: m.generatedColumn }
-        });
+        // skip invalid (not-connected) mapping
+        // refs: https://github.com/mozilla/source-map/blob/182f4459415de309667845af2b05716fcf9c59ad/lib/source-map-generator.js#L268-L275
+        if (typeof m.originalLine === 'number' && 0 < m.originalLine &&
+            typeof m.originalColumn === 'number' && 0 <= m.originalColumn &&
+            m.source) {
+            generator.addMapping({
+                source: m.source,
+                name: m.name,
+                original: { line: m.originalLine, column: m.originalColumn },
+                generated: { line: m.generatedLine + lineOffset, column: m.generatedColumn }
+            });
+        }
     });
     var outgoingSourceMap = JSON.parse(generator.toString());
     if (typeof incomingSourceMap.sourcesContent !== undefined) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "url": "git://github.com/twada/offset-sourcemap-lines.git"
   },
   "scripts": {
-    "test": "ava --verbose test/test.js"
+    "test": "ava --verbose test/test.js test/test-babel.js"
   }
 }

--- a/test/fixtures/compiled-with-babel.js
+++ b/test/fixtures/compiled-with-babel.js
@@ -1,0 +1,26 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+"use strict";
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var Entry = function () {
+    function Entry(name) {
+        _classCallCheck(this, Entry);
+
+        this.name = name;
+    }
+
+    _createClass(Entry, [{
+        key: "toString",
+        value: function toString() {
+            return this.name;
+        }
+    }]);
+
+    return Entry;
+}();
+
+},{}]},{},[1])
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm5vZGVfbW9kdWxlcy9icm93c2VyaWZ5L25vZGVfbW9kdWxlcy9icm93c2VyLXBhY2svX3ByZWx1ZGUuanMiLCJlbnRyeS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTs7Ozs7OztJQ0FNLEs7QUFDRixtQkFBWSxJQUFaLEVBQWtCO0FBQUE7O0FBQ2QsYUFBSyxJQUFMLEdBQVksSUFBWjtBQUNIOzs7O21DQUNVO0FBQ1AsbUJBQU8sS0FBSyxJQUFaO0FBQ0giLCJmaWxlIjoiZ2VuZXJhdGVkLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXNDb250ZW50IjpbIihmdW5jdGlvbiBlKHQsbixyKXtmdW5jdGlvbiBzKG8sdSl7aWYoIW5bb10pe2lmKCF0W29dKXt2YXIgYT10eXBlb2YgcmVxdWlyZT09XCJmdW5jdGlvblwiJiZyZXF1aXJlO2lmKCF1JiZhKXJldHVybiBhKG8sITApO2lmKGkpcmV0dXJuIGkobywhMCk7dmFyIGY9bmV3IEVycm9yKFwiQ2Fubm90IGZpbmQgbW9kdWxlICdcIitvK1wiJ1wiKTt0aHJvdyBmLmNvZGU9XCJNT0RVTEVfTk9UX0ZPVU5EXCIsZn12YXIgbD1uW29dPXtleHBvcnRzOnt9fTt0W29dWzBdLmNhbGwobC5leHBvcnRzLGZ1bmN0aW9uKGUpe3ZhciBuPXRbb11bMV1bZV07cmV0dXJuIHMobj9uOmUpfSxsLGwuZXhwb3J0cyxlLHQsbixyKX1yZXR1cm4gbltvXS5leHBvcnRzfXZhciBpPXR5cGVvZiByZXF1aXJlPT1cImZ1bmN0aW9uXCImJnJlcXVpcmU7Zm9yKHZhciBvPTA7bzxyLmxlbmd0aDtvKyspcyhyW29dKTtyZXR1cm4gc30pIiwiY2xhc3MgRW50cnkge1xuICAgIGNvbnN0cnVjdG9yKG5hbWUpIHtcbiAgICAgICAgdGhpcy5uYW1lID0gbmFtZTtcbiAgICB9XG4gICAgdG9TdHJpbmcoKSB7XG4gICAgICAgIHJldHVybiB0aGlzLm5hbWU7XG4gICAgfVxufVxuIl19

--- a/test/test-babel.js
+++ b/test/test-babel.js
@@ -1,0 +1,56 @@
+import test from 'ava';
+import offsetLines from '../index';
+import {SourceMapConsumer} from 'source-map';
+import * as conv from 'convert-source-map';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const code = fs.readFileSync(path.join(__dirname, 'fixtures', 'compiled-with-babel.js'), 'utf-8');
+const originalMap = conv.fromSource(code).toObject();
+const targetLine = {
+    source: 'entry.js',
+    line: 3
+};
+const offsettedMap = offsetLines(originalMap, 15);
+
+test('generated positions in originalMap', t => {
+    const consumer = new SourceMapConsumer(originalMap);
+    const generated = consumer.allGeneratedPositionsFor(targetLine);
+    t.same(generated, [
+        { line: 12, column: 0, lastColumn: null },
+        { line: 12, column: 17, lastColumn: null },
+        { line: 12, column: 24, lastColumn: null },
+        { line: 12, column: 13, lastColumn: null },
+        { line: 12, column: 20, lastColumn: null }
+    ]);
+});
+
+test('generated positions in offsetted SourceMap', t => {
+    const consumer = new SourceMapConsumer(offsettedMap);
+    const generated = consumer.allGeneratedPositionsFor(targetLine);
+    t.same(generated, [
+        { line: 27, column: 0, lastColumn: null },
+        { line: 27, column: 17, lastColumn: null },
+        { line: 27, column: 24, lastColumn: null },
+        { line: 27, column: 13, lastColumn: null },
+        { line: 27, column: 20, lastColumn: null }
+    ]);
+});
+
+test(`property [mappings] should be changed`, t => {
+    t.notSame(originalMap.mappings, offsettedMap.mappings);
+});
+
+const unchangedProps = [
+    'version',
+    'file',
+    'sourceRoot',
+    'sources',
+    'names',
+    'sourcesContent'
+];
+for (let propName of unchangedProps) {
+    test(`property [${propName}] should not be changed`, t => {
+        t.same(originalMap[propName], offsettedMap[propName]);
+    });
+}

--- a/test/test-babel.js
+++ b/test/test-babel.js
@@ -13,6 +13,17 @@ const targetLine = {
 };
 const offsettedMap = offsetLines(originalMap, 15);
 
+test('some invalid mapping in upstream sourcemap', t => {
+    const consumer = new SourceMapConsumer(originalMap);
+    const invalidMappings = [];
+    consumer.eachMapping((m) => {
+        if (m.source === null && m.originalLine === null && m.originalColumn === null) {
+            invalidMappings.push(m);
+        }
+    });
+    t.ok(0 < invalidMappings.length);
+});
+
 test('generated positions in originalMap', t => {
     const consumer = new SourceMapConsumer(originalMap);
     const generated = consumer.allGeneratedPositionsFor(targetLine);


### PR DESCRIPTION
Skip missing original lines and columns in sourcemap

refs: twada/licensify#17
refs: twada/licensify#18
